### PR TITLE
Implement silence-based audio splitting

### DIFF
--- a/intelligent_video/editor.py
+++ b/intelligent_video/editor.py
@@ -1,0 +1,45 @@
+import os
+import struct
+import wave
+from typing import List
+
+try:
+    import librosa
+except Exception:
+    import librosa_stub as librosa
+
+
+class VideoEditor:
+    def __init__(self, media_path: str):
+        self.media_path = media_path
+
+    @staticmethod
+    def _write_wav(path: str, audio: List[float], sr: int) -> None:
+        """Write a mono wav file from float samples."""
+        with wave.open(path, 'wb') as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(sr)
+            ints = [int(max(-1.0, min(1.0, s)) * 32767) for s in audio]
+            frames = struct.pack('<' + 'h' * len(ints), *ints)
+            wf.writeframes(frames)
+
+    def split_on_silence(self, top_db: int = 40, min_len: float = 0.5, output_dir: str | None = None) -> List[str]:
+        """Split the media on silent intervals using librosa and return segment paths."""
+        audio, sr = librosa.load(self.media_path, sr=None)
+        intervals = librosa.effects.split(audio, top_db=top_db)
+
+        output_dir = output_dir or os.path.dirname(self.media_path)
+        base = os.path.splitext(os.path.basename(self.media_path))[0]
+        segment_paths: List[str] = []
+
+        min_samples = int(min_len * sr)
+        for i, (start, end) in enumerate(intervals):
+            if end - start < min_samples:
+                continue
+            segment_audio = audio[start:end]
+            seg_path = os.path.join(output_dir, f"{base}_segment_{i}.wav")
+            self._write_wav(seg_path, segment_audio, sr)
+            segment_paths.append(seg_path)
+        return segment_paths
+

--- a/librosa_stub/__init__.py
+++ b/librosa_stub/__init__.py
@@ -1,0 +1,62 @@
+import wave
+import struct
+import math
+
+# Minimal stub of librosa-like functions for silence detection
+
+def load(path, sr=None, mono=True):
+    with wave.open(path, 'rb') as wf:
+        channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        framerate = wf.getframerate()
+        nframes = wf.getnframes()
+        frames = wf.readframes(nframes)
+    fmt_map = {1: 'b', 2: 'h', 4: 'i'}
+    fmt = '<' + fmt_map[sampwidth] * (len(frames) // sampwidth)
+    data = struct.unpack(fmt, frames)
+    if channels > 1:
+        mono_data = []
+        for i in range(0, len(data), channels):
+            mono_sample = sum(data[i:i+channels]) / channels
+            mono_data.append(mono_sample)
+        data = mono_data
+    max_amp = float(2 ** (8 * sampwidth - 1))
+    audio = [sample / max_amp for sample in data]
+    if sr and sr != framerate:
+        # naive resample
+        factor = sr / framerate
+        resampled = []
+        for i in range(int(len(audio) * factor)):
+            resampled.append(audio[int(i / factor)])
+        audio = resampled
+        framerate = sr
+    return audio, framerate
+
+class effects:
+    @staticmethod
+    def split(y, top_db=40, frame_length=2048, hop_length=512):
+        """Return non-silent intervals of ``y``."""
+        threshold = 10 ** (-top_db / 20)
+        flags = []
+        for i in range(0, len(y), hop_length):
+            window = y[i:i + frame_length]
+            if not window:
+                break
+            rms = math.sqrt(sum(s * s for s in window) / len(window))
+            flags.append(rms > threshold)
+
+        intervals = []
+        start = None
+        for idx, flag in enumerate(flags):
+            if flag:
+                if start is None:
+                    start = idx * hop_length
+            else:
+                if start is not None:
+                    end = idx * hop_length
+                    intervals.append((start, min(end, len(y))) )
+                    start = None
+        if start is not None:
+            intervals.append((start, len(y)))
+        return intervals
+

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,0 +1,40 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import wave
+import math
+
+from intelligent_video.editor import VideoEditor
+
+
+def _write_wav(path, samples, sr):
+    with wave.open(path, 'wb') as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        import struct
+        ints = [int(max(-1.0, min(1.0, s)) * 32767) for s in samples]
+        frames = struct.pack('<' + 'h' * len(ints), *ints)
+        wf.writeframes(frames)
+
+def generate_test_audio(path):
+    sr = 16000
+    tone = [math.sin(2 * math.pi * 440 * t / sr) for t in range(sr)]
+    silence = [0.0] * int(sr * 0.6)
+    audio = tone + silence + tone
+    _write_wav(path, audio, sr)
+
+
+def test_split_on_silence(tmp_path):
+    audio_path = tmp_path / "sample.wav"
+    generate_test_audio(str(audio_path))
+
+    editor = VideoEditor(str(audio_path))
+    segments = editor.split_on_silence(output_dir=str(tmp_path))
+
+    assert len(segments) == 2
+    for seg in segments:
+        assert os.path.exists(seg)
+        with wave.open(seg, 'rb') as wf:
+            duration = wf.getnframes() / wf.getframerate()
+            assert 0.9 <= duration <= 1.1
+


### PR DESCRIPTION
## Summary
- add minimal `librosa` stub with `load` and `effects.split`
- implement `VideoEditor.split_on_silence` using the stub
- provide unit test generating example audio and verifying split segments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f414e998c83268f1328aae14680f2